### PR TITLE
Charles' Emacs: Allow projects to have custom project name

### DIFF
--- a/users/dotfiles/charles/doom.d/config.el
+++ b/users/dotfiles/charles/doom.d/config.el
@@ -143,6 +143,19 @@
                            (project-root project)))
                  (t (apply orig-fun (list project)))))))
 
+(defun workspaces-project-unique-name-advice (orig-fun project-root)
+  (let ((custom-name (funcall projectile-project-name-function
+                              project-root)))
+    (if-let* ((orig-name (apply orig-fun (list project-root)))
+              (parts (split-string orig-name "/" t))
+              (path (cdr parts)))
+        (string-join (append path (list custom-name)) "/")
+      custom-name)))
+
+(after! (projectile persp-mode)
+  (advice-add '+workspaces-project-unique-name :around
+              #'workspaces-project-unique-name-advice))
+
 (set-formatter! 'alejandra '("alejandra" "--quiet") :modes '(nix-mode))
 
 ;;; config.el ends here


### PR DESCRIPTION
Because several of the projects I work with are part of monorepo setups, and are located at paths which have a generic final directory name (e.g. "ui"), it is preferable to specify a custom name for the project using a dir-local variable.

This also adds support for Doom Emacs' workspace feature to use that custom name when determining the workspace for a given project (e.g. on `projectile-switch-project`).