### PR TITLE
Charles: Use latest claude-agent-acp

### DIFF
--- a/users/charles/home.nix
+++ b/users/charles/home.nix
@@ -304,6 +304,7 @@
     unzip
     jetbrains.idea
     nodejs
+    bun
     dbeaver-bin
     whois
     jq

--- a/users/charles/home.nix
+++ b/users/charles/home.nix
@@ -284,6 +284,10 @@
     '';
 
     ".local/share/lombok.system.jar".source = "${pkgs.lombok}/share/java/lombok.jar";
+
+    ".npmrc".text = ''
+      prefix = ''${HOME}/.local/state/npm
+    '';
   };
 
   home.packages = with pkgs; [

--- a/users/charles/nixos.nix
+++ b/users/charles/nixos.nix
@@ -31,4 +31,22 @@
   programs.openvpn3.enable = true;
 
   security.pam.services.swaylock = {};
+
+  nixpkgs.overlays = [
+    (final: prev: {
+      claude-agent-acp = prev.claude-agent-acp.overrideAttrs (finalAttrs: prevAttrs: {
+        version = "0.26.0";
+
+        src = prevAttrs.src.overrideAttrs (oldSrc: {
+          owner = "agentclientprotocol";
+          hash = "sha256-2G8gjMCnk3W1I2+4sNsumL15ts9bLXAOMguCmwnzWSA=";
+        });
+
+        npmDeps = prev.fetchNpmDeps {
+          inherit (finalAttrs) src;
+          hash = "sha256-msm4L8Yi7ma2eHOYXbZx+Qtrx4TzK7FV3HpVzRhQ19o=";
+        };
+      });
+    })
+  ];
 }


### PR DESCRIPTION
This adds an overlay to update the `claude-agent-acp` package so that it uses the latest released version. Bun is also added for `charles` in order to run projects (such as `ccusage`) with `bunx`.