### PR TITLE
Chore: Update flake and devenv inputs

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1775742783,
-        "narHash": "sha256-2u8i+4s9hx6KEptCtCN2vn2nrFBXPBlTcI4wfVfLAio=",
+        "lastModified": 1779749056,
+        "narHash": "sha256-AtocdrunzuxTvSDn+82RntEhrs6TicM6Z4/zNQS9KKg=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "52fa484bd1a2ccba8c8025d41e41fdace52634e6",
+        "rev": "099ac65fcef79e88127bdc06adbd1ea94255274a",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
         "nixpkgs-src": "nixpkgs-src"
       },
       "locked": {
-        "lastModified": 1774287239,
-        "narHash": "sha256-W3krsWcDwYuA3gPWsFA24YAXxOFUL6iIlT6IknAoNSE=",
+        "lastModified": 1778507786,
+        "narHash": "sha256-HzSQCKMsMr8r55LwM1JuzIOB+8bzk0FEv6sItKvsfoY=",
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "fa7125ea7f1ae5430010a6e071f68375a39bd24c",
+        "rev": "8f24a228a782e24576b155d1e39f0d914b380691",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
     "nixpkgs-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1773840656,
-        "narHash": "sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cf7092bdd603554bd8b63c216e8943cf9b12512",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775683737,
-        "narHash": "sha256-oBYyowo6yfgb95Z78s3uTnAd9KkpJpwzjJbfnpLaM2Y=",
+        "lastModified": 1779726696,
+        "narHash": "sha256-/p37CB5n6Wpw250b0Lq0CYwNq2D8uGKzDoBulyLcQqA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7ba4ee4228ed36123c7cb75d50524b43514ef992",
+        "rev": "1a95e2efb477959b70b4a14c51035975c0481df6",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775423009,
-        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {

--- a/machines/hana/configuration.nix
+++ b/machines/hana/configuration.nix
@@ -128,9 +128,11 @@
       if rootless
       then {
         rootless =
+          lib.recursiveUpdate
           docker-config
-          // {
+          {
             setSocketVariable = true;
+            daemon.settings.dns = ["1.1.1.1" "8.8.8.8"];
           };
       }
       else docker-config

--- a/machines/hana/hardware.nix
+++ b/machines/hana/hardware.nix
@@ -22,13 +22,11 @@
       luks.devices.sys.device = "/dev/disk/by-uuid/b5b67eb0-d597-4d5c-80fd-952be392ed0b";
 
       # Custom udev rules for stage 1
-      extraUdevRulesCommands = let
-        hana-initrd-udev-rules = pkgs.callPackage ./packages/initrd-udev-rules/default.nix {
+      services.udev.packages = [
+        (pkgs.callPackage ./packages/initrd-udev-rules/default.nix {
           inherit pkgs;
-        };
-      in ''
-        cp -v ${hana-initrd-udev-rules}/lib/udev/rules.d/*.rules $out/
-      '';
+        })
+      ];
     };
 
     swraid = {
@@ -43,6 +41,7 @@
   fileSystems."/" = {
     device = "/dev/disk/by-uuid/7f502911-f8f9-49d8-b3eb-eb0e4b52842b";
     fsType = "ext4";
+    options = ["x-systemd.device-timeout=infinity"];
   };
 
   fileSystems."/efi" = {

--- a/users/charles/home.nix
+++ b/users/charles/home.nix
@@ -46,8 +46,6 @@
         }
       ];
 
-      ignores = [".dir-locals.el" ".projectile"];
-
       signing.format = null;
     };
 

--- a/users/charles/home.nix
+++ b/users/charles/home.nix
@@ -53,58 +53,53 @@
       enable = true;
       enableDefaultConfig = false;
 
-      matchBlocks = let
+      settings = let
         defaults = {
-          forwardAgent = false;
-          identitiesOnly = true;
+          ForwardAgent = false;
+          IdentitiesOnly = true;
         };
       in {
         "*" = {
-          compression = true;
-          addKeysToAgent = "3h";
+          Compression = true;
+          AddKeysToAgent = "3h";
         };
 
-        GitHub =
+        "github.com" =
           defaults
           // {
-            host = "github.com";
-            user = "git";
-            identityFile = "~/.ssh/github_ed25519";
+            User = "git";
+            IdentityFile = "~/.ssh/github_ed25519";
           };
 
-        GitLabCNC =
+        "gitlab_cnc" =
           defaults
           // {
-            host = "gitlab_cnc";
-            hostname = "gitlab.com";
-            user = "git";
-            identityFile = "~/.ssh/gitlab_cnc_ed25519";
+            HostName = "gitlab.com";
+            User = "git";
+            IdentityFile = "~/.ssh/gitlab_cnc_ed25519";
           };
 
-        AWS =
+        "*.amazonaws.com" =
           defaults
           // {
-            host = "*.amazonaws.com";
-            identityFile = "~/.ssh/aws_rsa4k";
-            forwardAgent = true;
+            IdentityFile = "~/.ssh/aws_rsa4k";
+            ForwardAgent = true;
           };
 
-        AdaWeb-Live =
+        "ada-web-live" =
           defaults
           // {
-            host = "ada-web-live";
-            hostname = "adadevelopersacademy.org";
-            user = "bitnami";
-            identityFile = "~/.ssh/ada_live_ed25519";
+            HostName = "adadevelopersacademy.org";
+            User = "bitnami";
+            IdentityFile = "~/.ssh/ada_live_ed25519";
           };
 
-        AdaWeb-Old =
+        "ada-web-old" =
           defaults
           // {
-            host = "ada-web-old";
-            hostname = "old.adadevelopersacademy.org";
-            user = "bitnami";
-            identityFile = "~/.ssh/ada_old_ed25519";
+            HostName = "old.adadevelopersacademy.org";
+            User = "bitnami";
+            IdentityFile = "~/.ssh/ada_old_ed25519";
           };
       };
     };

--- a/users/charles/home.nix
+++ b/users/charles/home.nix
@@ -85,22 +85,6 @@
             IdentityFile = "~/.ssh/aws_rsa4k";
             ForwardAgent = true;
           };
-
-        "ada-web-live" =
-          defaults
-          // {
-            HostName = "adadevelopersacademy.org";
-            User = "bitnami";
-            IdentityFile = "~/.ssh/ada_live_ed25519";
-          };
-
-        "ada-web-old" =
-          defaults
-          // {
-            HostName = "old.adadevelopersacademy.org";
-            User = "bitnami";
-            IdentityFile = "~/.ssh/ada_old_ed25519";
-          };
       };
     };
 

--- a/users/charles/home.nix
+++ b/users/charles/home.nix
@@ -125,7 +125,10 @@
       };
     };
 
-    firefox.enable = true;
+    firefox = {
+      enable = true;
+      configPath = "${config.xdg.configHome}/mozilla/firefox";
+    };
 
     direnv = {
       config.global = {

--- a/users/charles/nixos.nix
+++ b/users/charles/nixos.nix
@@ -31,22 +31,4 @@
   programs.openvpn3.enable = true;
 
   security.pam.services.swaylock = {};
-
-  nixpkgs.overlays = [
-    (final: prev: {
-      claude-agent-acp = prev.claude-agent-acp.overrideAttrs (finalAttrs: prevAttrs: {
-        version = "0.26.0";
-
-        src = prevAttrs.src.overrideAttrs (oldSrc: {
-          owner = "agentclientprotocol";
-          hash = "sha256-2G8gjMCnk3W1I2+4sNsumL15ts9bLXAOMguCmwnzWSA=";
-        });
-
-        npmDeps = prev.fetchNpmDeps {
-          inherit (finalAttrs) src;
-          hash = "sha256-msm4L8Yi7ma2eHOYXbZx+Qtrx4TzK7FV3HpVzRhQ19o=";
-        };
-      });
-    })
-  ];
 }


### PR DESCRIPTION
Updates the NixOS configuration's flake inputs, the inputs for devenv, and has fixes for deprecated / changed modules in NixOS and Home Manager:
* Stage 1 initrd uses systemd now, so custom udev rules packages are configured differently and the timeout waiting for the root filesystem has been disabled (because it's LVM ontop of LUKS)
* Home Manager's SSH module has deprecated `matchBlocks`, so the configuration now uses `settings` instead
* Home Manager's Firefox module defaults the config path in >=26.05 to be within `$XDG_CONFIG_HOME` to match the default in Firefox 147, and configs from older versions should set that path explicitly
* The `claude-agent-acp` package was updated to a more recent version and no longer requires an override

Additionally some minor configuration changes unrelated to updates:
* Rootless docker daemon config includes public DNS addresses, because it cannot reach the host's DNS resolver
* Global Gitignore configuration has been removed as it was not being used
* SSH client configurations for Ada website hosts have been removed