### PR TITLE
Charles: use wmenu as sway launcher

### DIFF
--- a/users/charles/home.nix
+++ b/users/charles/home.nix
@@ -173,6 +173,7 @@
         modifier = "Mod4";
         fonts = fontsSetting;
         terminal = "alacritty";
+        menu = "${pkgs.wmenu}/bin/wmenu-run";
 
         keybindings = let
           modifier = config.wayland.windowManager.sway.config.modifier;
@@ -309,6 +310,7 @@
     mailutils
     claude-code
     claude-agent-acp
+    wmenu
 
     awscli2
     kubectl


### PR DESCRIPTION
- set sway config.menu to wmenu-run (replaces the dmenu default bound to Mod+d)
- add wmenu to home.packages so wmenu/wmenu-run are on PATH (also usable as the hana screencast default chooser)