### PR TITLE
Charles: Login service

### DIFF
--- a/users/charles/home.nix
+++ b/users/charles/home.nix
@@ -280,6 +280,11 @@
   };
 
   home.packages = with pkgs; [
+    # Send sway's log output to the journal (tagged sway) instead of the tty
+    (lib.hiPrio (writeShellScriptBin "sway" ''
+      exec ${systemd}/bin/systemd-cat --identifier=sway ${config.wayland.windowManager.sway.package}/bin/sway "$@"
+    ''))
+
     wl-clipboard
     swaylock
     ripgrep

--- a/users/charles/nixos.nix
+++ b/users/charles/nixos.nix
@@ -32,11 +32,7 @@
 
   security.pam.services.swaylock = {};
 
-  # Log in via greetd + tuigreet on tty1, then launch Sway. greetd runs the
-  # session through `sh` and sources /etc/profile + ~/.profile, so `sway`
-  # resolves to the home-manager-wrapped binary (carrying --unsupported-gpu
-  # and the session env). Hit F2 in tuigreet to override the command for a
-  # single login (e.g. `sway --debug`).
+  # Log in via greetd + tuigreet on tty1, then launch Sway
   services.greetd = {
     enable = true;
     settings.default_session = {

--- a/users/charles/nixos.nix
+++ b/users/charles/nixos.nix
@@ -31,4 +31,17 @@
   programs.openvpn3.enable = true;
 
   security.pam.services.swaylock = {};
+
+  # Log in via greetd + tuigreet on tty1, then launch Sway. greetd runs the
+  # session through `sh` and sources /etc/profile + ~/.profile, so `sway`
+  # resolves to the home-manager-wrapped binary (carrying --unsupported-gpu
+  # and the session env). Hit F2 in tuigreet to override the command for a
+  # single login (e.g. `sway --debug`).
+  services.greetd = {
+    enable = true;
+    settings.default_session = {
+      command = "${pkgs.tuigreet}/bin/tuigreet --time --remember --cmd sway";
+      user = "greeter";
+    };
+  };
 }


### PR DESCRIPTION
This updates hana and charles to use greetd and tuigreet for login, running as a systemd service, and to start Sway upon login, running with `systemd-cat` so that log output is sent to the systemd journal.